### PR TITLE
updated docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@ elasticsearch-demo
 
 To start up the docker container with elasticsearch:
 ```docker-compose up```
+
+## Requirements
+Elasticsearch version must be 6.7 to match the latest version provided by Amazon Elasticsearch service.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
 version: "3.7"
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.0
-    container_name: es0
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.7.0
+    container_name: es
     environment:
-      - node.name=es0
-      - cluster.initial_master_nodes=es0
+      - node.name=es
+      - cluster.initial_master_nodes=es
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
@@ -14,7 +14,7 @@ services:
         soft: -1
         hard: -1
     volumes:
-      - esdata0:/usr/share/elasticsearch/data
+      - esdata:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
     networks:


### PR DESCRIPTION
changed the image used to create the container: now ```docker-compose up```creates a container with version 6.7 of elasticsearch (not the latest avaiable as before, 7.3) as it is the latest version provided by amazon elasticsearch service